### PR TITLE
Feat[#5] dockefile 작성

### DIFF
--- a/Internal/docker-images/all-spark-notebook/.dockerignore
+++ b/Internal/docker-images/all-spark-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/all-spark-notebook/Dockerfile
+++ b/Internal/docker-images/all-spark-notebook/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/pyspark-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# RSpark config
+ENV R_LIBS_USER "${SPARK_HOME}/R/lib"
+RUN fix-permissions "${R_LIBS_USER}"
+
+# R pre-requisites
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    fonts-dejavu \
+    gfortran \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER ${NB_UID}
+
+# R packages including IRKernel which gets installed globally.
+RUN mamba install --yes \
+    'r-base' \
+    'r-ggplot2' \
+    'r-irkernel' \
+    'r-rcurl' \
+    'r-sparklyr' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/Internal/docker-images/all-spark-notebook/README.md
+++ b/Internal/docker-images/all-spark-notebook/README.md
@@ -1,0 +1,13 @@
+# Jupyter Notebook Python, R, Spark Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/all-spark-notebook.svg)](https://hub.docker.com/r/jupyter/all-spark-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/all-spark-notebook.svg)](https://hub.docker.com/r/jupyter/all-spark-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/all-spark-notebook/latest)](https://hub.docker.com/r/jupyter/all-spark-notebook/ "jupyter/all-spark-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/all-spark-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-all-spark-notebook)
+- [Image Specifics :: Apache Spark](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/specifics.html#apache-spark)

--- a/Internal/docker-images/base-notebook/.dockerignore
+++ b/Internal/docker-images/base-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/base-notebook/Dockerfile
+++ b/Internal/docker-images/base-notebook/Dockerfile
@@ -1,0 +1,92 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# ARG OWNER=jupyter
+ARG OWNER=quiltbase
+ARG BASE_CONTAINER=${OWNER}/quilt-foundation:latest
+FROM $BASE_CONTAINER
+
+LABEL maintainer="GwooTeam <gwooteam@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Install all OS dependencies for Server that starts but lacks all
+# features (e.g., download as all possible file formats)
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    fonts-liberation \
+    # - pandoc is used to convert notebooks to html files
+    #   it's not present in aarch64 ubuntu image, so we install it here
+    pandoc \
+    # - run-one - a wrapper script that runs no more
+    #   than one unique  instance  of  some  command with a unique set of arguments,
+    #   we use `run-one-constantly` to support `RESTARTABLE` option
+    run-one && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER ${NB_UID}
+
+# Install JupyterLab, Jupyter Notebook, JupyterHub and NBClassic
+# Generate a Jupyter Server config
+# Cleanup temporary files
+# Correct permissions
+# Do all this in a single RUN command to avoid duplicating all of the
+# files across image layers when the permissions change
+WORKDIR /tmp
+RUN mamba install --yes \
+    'jupyterlab' \
+    'notebook' \
+    'jupyterhub' \
+    'nbclassic' && \
+    jupyter server --generate-config && \
+    mamba clean --all -f -y && \
+    npm cache clean --force && \
+    jupyter lab clean && \
+    rm -rf "/home/${NB_USER}/.cache/yarn" && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+ENV JUPYTER_PORT=8888
+EXPOSE $JUPYTER_PORT
+
+# Configure container startup
+CMD ["start-notebook.sh"]
+
+# Copy local files as late as possible to avoid cache busting
+COPY start-notebook.sh start-singleuser.sh /usr/local/bin/
+
+# add permission on start-notebook.sh
+USER root
+RUN chmod +x /usr/local/bin/start-notebook.sh
+USER ${NB_UID}
+
+COPY jupyter_server_config.py docker_healthcheck.py /etc/jupyter/
+
+# # 230927 added
+# # add jupyter notebook config
+# USER root
+# RUN pip install jupyter_contrib_nbextensions \
+#     # pip install --upgrade notebook==6.4.12 \
+#     jupyter contrib nbextension install --user
+
+# COPY jupyter_notebook_config.py ~/.jupyter/
+
+# USER ${NB_UID}
+
+# Fix permissions on /etc/jupyter as root
+USER root
+RUN fix-permissions /etc/jupyter/
+
+# HEALTHCHECK documentation: https://docs.docker.com/engine/reference/builder/#healthcheck
+# This healtcheck works well for `lab`, `notebook`, `nbclassic`, `server` and `retro` jupyter commands
+# https://github.com/jupyter/docker-stacks/issues/915#issuecomment-1068528799
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
+    CMD /etc/jupyter/docker_healthcheck.py || exit 1
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER ${NB_UID}
+
+WORKDIR "${HOME}"

--- a/Internal/docker-images/base-notebook/README.md
+++ b/Internal/docker-images/base-notebook/README.md
@@ -1,0 +1,12 @@
+# Base Jupyter Notebook Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/base-notebook.svg)](https://hub.docker.com/r/jupyter/base-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/base-notebook.svg)](https://hub.docker.com/r/jupyter/base-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/base-notebook/latest)](https://hub.docker.com/r/jupyter/base-notebook/ "jupyter/base-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/base-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-base-notebook)

--- a/Internal/docker-images/base-notebook/docker_healthcheck.py
+++ b/Internal/docker-images/base-notebook/docker_healthcheck.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import json
+import os
+from pathlib import Path
+
+import requests
+
+# A number of operations below deliberately don't check for possible errors
+# As this is a healthcheck, it should succeed or raise an exception on error
+
+runtime_dir = Path("/home/") / os.environ["NB_USER"] / ".local/share/jupyter/runtime/"
+json_file = next(runtime_dir.glob("*server-*.json"))
+
+url = json.loads(json_file.read_bytes())["url"]
+url = url + "api"
+
+proxies = {
+    "http": "",
+    "https": "",
+}
+
+r = requests.get(url, proxies=proxies, verify=False)  # request without SSL verification
+r.raise_for_status()
+print(r.content)

--- a/Internal/docker-images/base-notebook/jupyter_server_config.py
+++ b/Internal/docker-images/base-notebook/jupyter_server_config.py
@@ -1,0 +1,58 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# mypy: ignore-errors
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+from jupyter_core.paths import jupyter_data_dir
+
+c = get_config()  # noqa: F821
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.open_browser = False
+
+# to output both image/svg+xml and application/pdf plot formats in the notebook file
+c.InlineBackend.figure_formats = {"png", "jpeg", "svg", "pdf"}
+
+# https://github.com/jupyter/notebook/issues/3130
+c.FileContentsManager.delete_to_trash = False
+
+# Generate a self-signed certificate
+OPENSSL_CONFIG = """\
+[req]
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+"""
+if "GEN_CERT" in os.environ:
+    dir_name = Path(jupyter_data_dir())
+    dir_name.mkdir(parents=True, exist_ok=True)
+    pem_file = dir_name / "notebook.pem"
+
+    # Generate an openssl.cnf file to set the distinguished name
+    cnf_file = Path(os.getenv("CONDA_DIR", "/usr/lib")) / "ssl/openssl.cnf"
+    if not cnf_file.exists():
+        cnf_file.write_text(OPENSSL_CONFIG)
+
+    # Generate a certificate if one doesn't exist on disk
+    subprocess.check_call(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-newkey=rsa:2048",
+            "-days=365",
+            "-nodes",
+            "-x509",
+            "-subj=/C=XX/ST=XX/L=XX/O=generated/CN=generated",
+            f"-keyout={pem_file}",
+            f"-out={pem_file}",
+        ]
+    )
+    # Restrict access to the file
+    pem_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    c.ServerApp.certfile = str(pem_file)
+
+# Change default umask for all subprocesses of the Server if set in the environment
+if "NB_UMASK" in os.environ:
+    os.umask(int(os.environ["NB_UMASK"], 8))

--- a/Internal/docker-images/base-notebook/start-notebook.sh
+++ b/Internal/docker-images/base-notebook/start-notebook.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# The Jupyter command to launch
+# JupyterLab by default
+DOCKER_STACKS_JUPYTER_CMD="${DOCKER_STACKS_JUPYTER_CMD:=lab}"
+
+if [[ -n "${JUPYTERHUB_API_TOKEN}" ]]; then
+    echo "WARNING: using start-singleuser.sh instead of start-notebook.sh to start a server associated with JupyterHub."
+    exec /usr/local/bin/start-singleuser.sh "$@"
+fi
+
+wrapper=""
+if [[ "${RESTARTABLE}" == "yes" ]]; then
+    wrapper="run-one-constantly"
+fi
+
+# shellcheck disable=SC1091,SC2086
+exec /usr/local/bin/start.sh ${wrapper} jupyter ${DOCKER_STACKS_JUPYTER_CMD} ${NOTEBOOK_ARGS} "$@"

--- a/Internal/docker-images/base-notebook/start-singleuser.sh
+++ b/Internal/docker-images/base-notebook/start-singleuser.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# set default ip to 0.0.0.0
+if [[ "${NOTEBOOK_ARGS} $*" != *"--ip="* ]]; then
+    NOTEBOOK_ARGS="--ip=0.0.0.0 ${NOTEBOOK_ARGS}"
+fi
+
+# shellcheck disable=SC1091,SC2086
+. /usr/local/bin/start.sh jupyterhub-singleuser ${NOTEBOOK_ARGS} "$@"

--- a/Internal/docker-images/datascience-notebook/.dockerignore
+++ b/Internal/docker-images/datascience-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/datascience-notebook/Dockerfile
+++ b/Internal/docker-images/datascience-notebook/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/scipy-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# R pre-requisites
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    fonts-dejavu \
+    gfortran \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Julia dependencies
+# install Julia packages in /opt/julia instead of ${HOME}
+ENV JULIA_DEPOT_PATH=/opt/julia \
+    JULIA_PKGDIR=/opt/julia
+
+# Setup Julia
+RUN /opt/setup-scripts/setup-julia.bash
+
+USER ${NB_UID}
+
+# Setup IJulia kernel & other packages
+RUN /opt/setup-scripts/setup-julia-packages.bash
+
+# R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
+RUN mamba install --yes \
+    'r-base' \
+    'r-caret' \
+    'r-crayon' \
+    'r-devtools' \
+    'r-e1071' \
+    'r-forecast' \
+    'r-hexbin' \
+    'r-htmltools' \
+    'r-htmlwidgets' \
+    'r-irkernel' \
+    'r-nycflights13' \
+    'r-randomforest' \
+    'r-rcurl' \
+    'r-rmarkdown' \
+    'r-rodbc' \
+    'r-rsqlite' \
+    'r-shiny' \
+    'r-tidymodels' \
+    'r-tidyverse' \
+    'rpy2' \
+    'unixodbc' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/Internal/docker-images/datascience-notebook/README.md
+++ b/Internal/docker-images/datascience-notebook/README.md
@@ -1,0 +1,12 @@
+# Jupyter Notebook Data Science Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/datascience-notebook.svg)](https://hub.docker.com/r/jupyter/datascience-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/datascience-notebook.svg)](https://hub.docker.com/r/jupyter/datascience-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/datascience-notebook/latest)](https://hub.docker.com/r/jupyter/datascience-notebook/ "jupyter/datascience-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/datascience-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-datascience-notebook)

--- a/Internal/docker-images/docker-stacks-foundation/.dockerignore
+++ b/Internal/docker-images/docker-stacks-foundation/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/docker-stacks-foundation/Dockerfile
+++ b/Internal/docker-images/docker-stacks-foundation/Dockerfile
@@ -1,0 +1,142 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# Ubuntu 22.04 (jammy)
+# https://hub.docker.com/_/ubuntu/tags?page=1&name=jammy
+ARG ROOT_CONTAINER=ubuntu:22.04
+
+FROM $ROOT_CONTAINER
+
+LABEL maintainer="GwooTeam <gwooteam@googlegroups.com>"
+ARG NB_USER="node"
+ARG NB_UID="1000"
+ARG NB_GID="100"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Install all OS dependencies for Server that starts
+# but lacks all features (e.g., download as all possible file formats)
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update --yes && \
+    # - apt-get upgrade is run to patch known vulnerabilities in apt-get packages as
+    #   the ubuntu base image is rebuilt too seldom sometimes (less than once a month)
+    apt-get upgrade --yes && \
+    apt-get install --yes --no-install-recommends \
+    # - bzip2 is necessary to extract the micromamba executable.
+    bzip2 \
+    ca-certificates \
+    locales \
+    sudo \
+    # - tini is installed as a helpful container entrypoint that reaps zombie
+    #   processes and such of the actual executable we want to start, see
+    #   https://github.com/krallin/tini#why-tini for details.
+    tini \
+    wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+# Configure environment
+ENV CONDA_DIR=/opt/conda \
+    SHELL=/bin/bash \
+    NB_USER="${NB_USER}" \
+    NB_UID=${NB_UID} \
+    NB_GID=${NB_GID} \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+ENV PATH="${CONDA_DIR}/bin:${PATH}" \
+    HOME="/home/${NB_USER}"
+
+# Copy a script that we will use to correct permissions after running certain commands
+COPY fix-permissions /usr/local/bin/fix-permissions
+RUN chmod a+rx /usr/local/bin/fix-permissions
+
+# Enable prompt color in the skeleton .bashrc before creating the default NB_USER
+# hadolint ignore=SC2016
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
+   # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
+   echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >> /etc/skel/.bashrc
+
+# Create NB_USER with name jovyan user with UID=1000 and in the 'users' group
+# and make sure these dirs are writable by the `users` group.
+RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
+    sed -i.bak -e 's/^%admin/#%admin/' /etc/sudoers && \
+    sed -i.bak -e 's/^%sudo/#%sudo/' /etc/sudoers && \
+    useradd --no-log-init --create-home --shell /bin/bash --uid "${NB_UID}" --no-user-group "${NB_USER}" && \
+    mkdir -p "${CONDA_DIR}" && \
+    chown "${NB_USER}:${NB_GID}" "${CONDA_DIR}" && \
+    chmod g+w /etc/passwd && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+USER ${NB_UID}
+
+# Pin python version here, or set it to "default"
+ARG PYTHON_VERSION=3.11
+
+# Setup work directory for backward-compatibility
+RUN mkdir "/home/${NB_USER}/work" && \
+    fix-permissions "/home/${NB_USER}"
+
+# Download and install Micromamba, and initialize Conda prefix.
+#   <https://github.com/mamba-org/mamba#micromamba>
+#   Similar projects using Micromamba:
+#     - Micromamba-Docker: <https://github.com/mamba-org/micromamba-docker>
+#     - repo2docker: <https://github.com/jupyterhub/repo2docker>
+# Install Python, Mamba and jupyter_core
+# Cleanup temporary files and remove Micromamba
+# Correct permissions
+# Do all this in a single RUN command to avoid duplicating all of the
+# files across image layers when the permissions change
+COPY --chown="${NB_UID}:${NB_GID}" initial-condarc "${CONDA_DIR}/.condarc"
+WORKDIR /tmp
+RUN set -x && \
+    arch=$(uname -m) && \
+    if [ "${arch}" = "x86_64" ]; then \
+        # Should be simpler, see <https://github.com/mamba-org/mamba/issues/1437>
+        arch="64"; \
+    fi && \
+    wget --progress=dot:giga -O /tmp/micromamba.tar.bz2 \
+        "https://micromamba.snakepit.net/api/micromamba/linux-${arch}/latest" && \
+    tar -xvjf /tmp/micromamba.tar.bz2 --strip-components=1 bin/micromamba && \
+    rm /tmp/micromamba.tar.bz2 && \
+    PYTHON_SPECIFIER="python=${PYTHON_VERSION}" && \
+    if [[ "${PYTHON_VERSION}" == "default" ]]; then PYTHON_SPECIFIER="python"; fi && \
+    # Install the packages
+    ./micromamba install \
+        --root-prefix="${CONDA_DIR}" \
+        --prefix="${CONDA_DIR}" \
+        --yes \
+        "${PYTHON_SPECIFIER}" \
+        'mamba' \
+        'jupyter_core' && \
+    rm micromamba && \
+    # Pin major.minor version of python
+    mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# Configure container startup
+ENTRYPOINT ["tini", "-g", "--"]
+CMD ["start.sh"]
+
+USER root
+# Copy local files as late as possible to avoid cache busting
+COPY run-hooks.sh start.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/start.sh
+
+# Create dirs for startup hooks
+RUN mkdir /usr/local/bin/start-notebook.d && \
+    mkdir /usr/local/bin/before-notebook.d
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER ${NB_UID}
+
+WORKDIR "${HOME}"

--- a/Internal/docker-images/docker-stacks-foundation/README.md
+++ b/Internal/docker-images/docker-stacks-foundation/README.md
@@ -1,0 +1,12 @@
+# Foundation Jupyter Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/docker-stacks-foundation.svg)](https://hub.docker.com/r/jupyter/docker-stacks-foundation/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/docker-stacks-foundation.svg)](https://hub.docker.com/r/jupyter/docker-stacks-foundation/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/docker-stacks-foundation/latest)](https://hub.docker.com/r/jupyter/docker-stacks-foundation/ "jupyter/docker-stacks-foundation image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/docker-stacks-foundation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-docker-stacks-foundation)

--- a/Internal/docker-images/docker-stacks-foundation/fix-permissions
+++ b/Internal/docker-images/docker-stacks-foundation/fix-permissions
@@ -1,0 +1,35 @@
+#!/bin/bash
+# set permissions on a directory
+# after any installation, if a directory needs to be (human) user-writable,
+# run this script on it.
+# It will make everything in the directory owned by the group ${NB_GID}
+# and writable by that group.
+# Deployments that want to set a specific user id can preserve permissions
+# by adding the `--group-add users` line to `docker run`.
+
+# uses find to avoid touching files that already have the right permissions,
+# which would cause massive image explosion
+
+# right permissions are:
+# group=${NB_GID}
+# AND permissions include group rwX (directory-execute)
+# AND directories have setuid,setgid bits set
+
+set -e
+
+for d in "$@"; do
+    find "${d}" \
+        ! \( \
+            -group "${NB_GID}" \
+            -a -perm -g+rwX \
+        \) \
+        -exec chgrp "${NB_GID}" -- {} \+ \
+        -exec chmod g+rwX -- {} \+
+    # setuid, setgid *on directories only*
+    find "${d}" \
+        \( \
+            -type d \
+            -a ! -perm -6000 \
+        \) \
+        -exec chmod +6000 -- {} \+
+done

--- a/Internal/docker-images/docker-stacks-foundation/initial-condarc
+++ b/Internal/docker-images/docker-stacks-foundation/initial-condarc
@@ -1,0 +1,6 @@
+# Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
+
+auto_update_conda: false
+show_channel_urls: true
+channels:
+  - conda-forge

--- a/Internal/docker-images/docker-stacks-foundation/run-hooks.sh
+++ b/Internal/docker-images/docker-stacks-foundation/run-hooks.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# The run-hooks.sh script looks for *.sh scripts to source
+# and executable files to run within a passed directory
+
+if [ "$#" -ne 1 ]; then
+    echo "Should pass exactly one directory"
+    return 1
+fi
+
+if [[ ! -d "${1}" ]] ; then
+    echo "Directory ${1} doesn't exist or is not a directory"
+    return 1
+fi
+
+echo "Running hooks in: ${1} as uid: $(id -u) gid: $(id -g)"
+for f in "${1}/"*; do
+    # Hadling a case when the directory is empty
+    [ -e "${f}" ] || continue
+    case "${f}" in
+        *.sh)
+            echo "Sourcing shell script: ${f}"
+            # shellcheck disable=SC1090
+            source "${f}"
+            # shellcheck disable=SC2181
+            if [ $? -ne 0 ] ; then
+                echo "${f} has failed, continuing execution"
+            fi
+            ;;
+        *)
+            if [ -x "${f}" ] ; then
+                echo "Running executable: ${f}"
+                "${f}"
+                # shellcheck disable=SC2181
+                if [ $? -ne 0 ] ; then
+                    echo "${f} has failed, continuing execution"
+                fi
+            else
+                echo "Ignoring non-executable: ${f}"
+            fi
+            ;;
+    esac
+done
+echo "Done running hooks in: ${1}"

--- a/Internal/docker-images/docker-stacks-foundation/start.sh
+++ b/Internal/docker-images/docker-stacks-foundation/start.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# The _log function is used for everything this script wants to log. It will
+# always log errors and warnings, but can be silenced for other messages
+# by setting JUPYTER_DOCKER_STACKS_QUIET environment variable.
+_log () {
+    if [[ "$*" == "ERROR:"* ]] || [[ "$*" == "WARNING:"* ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
+        echo "$@"
+    fi
+}
+_log "Entered start.sh with args:" "$@"
+
+# A helper function to unset env vars listed in the value of the env var
+# JUPYTER_ENV_VARS_TO_UNSET.
+unset_explicit_env_vars () {
+    if [ -n "${JUPYTER_ENV_VARS_TO_UNSET}" ]; then
+        for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',' ' '); do
+            _log "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
+            unset "${env_var_to_unset}"
+        done
+        unset JUPYTER_ENV_VARS_TO_UNSET
+    fi
+}
+
+
+# Default to starting bash if no command was specified
+if [ $# -eq 0 ]; then
+    cmd=( "bash" )
+else
+    cmd=( "$@" )
+fi
+
+# NOTE: This hook will run as the user the container was started with!
+# shellcheck disable=SC1091
+source /usr/local/bin/run-hooks.sh /usr/local/bin/start-notebook.d
+
+# If the container started as the root user, then we have permission to refit
+# the node user, and ensure file permissions, grant sudo rights, and such
+# things before we run the command passed to start.sh as the desired user
+# (NB_USER).
+#
+if [ "$(id -u)" == 0 ] ; then
+    # Environment variables:
+    # - NB_USER: the desired username and associated home folder
+    # - NB_UID: the desired user id
+    # - NB_GID: a group id we want our user to belong to
+    # - NB_GROUP: a group name we want for the group
+    # - GRANT_SUDO: a boolean ("1" or "yes") to grant the user sudo rights
+    # - CHOWN_HOME: a boolean ("1" or "yes") to chown the user's home folder
+    # - CHOWN_EXTRA: a comma separated list of paths to chown
+    # - CHOWN_HOME_OPTS / CHOWN_EXTRA_OPTS: arguments to the chown commands
+
+    # Refit the node user to the desired the user (NB_USER)
+    if id node &> /dev/null ; then
+        if ! usermod --home "/home/${NB_USER}" --login "${NB_USER}" node 2>&1 | grep "no changes" > /dev/null; then
+            _log "Updated the node user:"
+            _log "- username: node       -> ${NB_USER}"
+            _log "- home dir: /home/node -> /home/${NB_USER}"
+        fi
+    elif ! id -u "${NB_USER}" &> /dev/null; then
+        _log "ERROR: Neither the node user or '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
+        exit 1
+    fi
+    # Ensure the desired user (NB_USER) gets its desired user id (NB_UID) and is
+    # a member of the desired group (NB_GROUP, NB_GID)
+    if [ "${NB_UID}" != "$(id -u "${NB_USER}")" ] || [ "${NB_GID}" != "$(id -g "${NB_USER}")" ]; then
+        _log "Update ${NB_USER}'s UID:GID to ${NB_UID}:${NB_GID}"
+        # Ensure the desired group's existence
+        if [ "${NB_GID}" != "$(id -g "${NB_USER}")" ]; then
+            groupadd --force --gid "${NB_GID}" --non-unique "${NB_GROUP:-${NB_USER}}"
+        fi
+        # Recreate the desired user as we want it
+        userdel "${NB_USER}"
+        useradd --no-log-init --home "/home/${NB_USER}" --shell /bin/bash --uid "${NB_UID}" --gid "${NB_GID}" --groups 100 "${NB_USER}"
+    fi
+
+    # Move or symlink the node home directory to the desired users home
+    # directory if it doesn't already exist, and update the current working
+    # directory to the new location if needed.
+    if [[ "${NB_USER}" != "node" ]]; then
+        if [[ ! -e "/home/${NB_USER}" ]]; then
+            _log "Attempting to copy /home/node to /home/${NB_USER}..."
+            mkdir "/home/${NB_USER}"
+            if cp -a /home/node/. "/home/${NB_USER}/"; then
+                _log "Success!"
+            else
+                _log "Failed to copy data from /home/node to /home/${NB_USER}!"
+                _log "Attempting to symlink /home/node to /home/${NB_USER}..."
+                if ln -s /home/node "/home/${NB_USER}"; then
+                    _log "Success creating symlink!"
+                else
+                    _log "ERROR: Failed copy data from /home/node to /home/${NB_USER} or to create symlink!"
+                    exit 1
+                fi
+            fi
+        fi
+        # Ensure the current working directory is updated to the new path
+        if [[ "${PWD}/" == "/home/node/"* ]]; then
+            new_wd="/home/${NB_USER}/${PWD:13}"
+            _log "Changing working directory to ${new_wd}"
+            cd "${new_wd}"
+        fi
+    fi
+
+    # Optionally ensure the desired user get filesystem ownership of it's home
+    # folder and/or additional folders
+    if [[ "${CHOWN_HOME}" == "1" || "${CHOWN_HOME}" == "yes" ]]; then
+        _log "Ensuring /home/${NB_USER} is owned by ${NB_UID}:${NB_GID} ${CHOWN_HOME_OPTS:+(chown options: ${CHOWN_HOME_OPTS})}"
+        # shellcheck disable=SC2086
+        chown ${CHOWN_HOME_OPTS} "${NB_UID}:${NB_GID}" "/home/${NB_USER}"
+    fi
+    if [ -n "${CHOWN_EXTRA}" ]; then
+        for extra_dir in $(echo "${CHOWN_EXTRA}" | tr ',' ' '); do
+            _log "Ensuring ${extra_dir} is owned by ${NB_UID}:${NB_GID} ${CHOWN_EXTRA_OPTS:+(chown options: ${CHOWN_EXTRA_OPTS})}"
+            # shellcheck disable=SC2086
+            chown ${CHOWN_EXTRA_OPTS} "${NB_UID}:${NB_GID}" "${extra_dir}"
+        done
+    fi
+
+    # Update potentially outdated environment variables since image build
+    export XDG_CACHE_HOME="/home/${NB_USER}/.cache"
+
+    # Prepend ${CONDA_DIR}/bin to sudo secure_path
+    sed -r "s#Defaults\s+secure_path\s*=\s*\"?([^\"]+)\"?#Defaults secure_path=\"${CONDA_DIR}/bin:\1\"#" /etc/sudoers | grep secure_path > /etc/sudoers.d/path
+
+    # Optionally grant passwordless sudo rights for the desired user
+    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == "yes" ]]; then
+        _log "Granting ${NB_USER} passwordless sudo rights!"
+        echo "${NB_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/added-by-start-script
+    fi
+
+    # NOTE: This hook is run as the root user!
+    # shellcheck disable=SC1091
+    source /usr/local/bin/run-hooks.sh /usr/local/bin/before-notebook.d
+    unset_explicit_env_vars
+
+    _log "Running as ${NB_USER}:" "${cmd[@]}"
+    exec sudo --preserve-env --set-home --user "${NB_USER}" \
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+        PATH="${PATH}" \
+        PYTHONPATH="${PYTHONPATH:-}" \
+        "${cmd[@]}"
+        # Notes on how we ensure that the environment that this container is started
+        # with is preserved (except vars listed in JUPYTER_ENV_VARS_TO_UNSET) when
+        # we transition from running as root to running as NB_USER.
+        #
+        # - We use `sudo` to execute the command as NB_USER. What then
+        #   happens to the environment will be determined by configuration in
+        #   /etc/sudoers and /etc/sudoers.d/* as well as flags we pass to the sudo
+        #   command. The behavior can be inspected with `sudo -V` run as root.
+        #
+        #   ref: `man sudo`    https://linux.die.net/man/8/sudo
+        #   ref: `man sudoers` https://www.sudo.ws/docs/man/sudoers.man/
+        #
+        # - We use the `--preserve-env` flag to pass through most environment
+        #   variables, but understand that exceptions are caused by the sudoers
+        #   configuration: `env_delete` and `env_check`.
+        #
+        # - We use the `--set-home` flag to set the HOME variable appropriately.
+        #
+        # - To reduce the default list of variables deleted by sudo, we could have
+        #   used `env_delete` from /etc/sudoers. It has higher priority than the
+        #   `--preserve-env` flag and the `env_keep` configuration.
+        #
+        # - We preserve LD_LIBRARY_PATH, PATH and PYTHONPATH explicitly. Note however that sudo
+        #   resolves `${cmd[@]}` using the "secure_path" variable we modified
+        #   above in /etc/sudoers.d/path. Thus PATH is irrelevant to how the above
+        #   sudo command resolves the path of `${cmd[@]}`. The PATH will be relevant
+        #   for resolving paths of any subprocesses spawned by `${cmd[@]}`.
+
+# The container didn't start as the root user, so we will have to act as the
+# user we started as.
+else
+    # Warn about misconfiguration of: granting sudo rights
+    if [[ "${GRANT_SUDO}" == "1" || "${GRANT_SUDO}" == "yes" ]]; then
+        _log "WARNING: container must be started as root to grant sudo permissions!"
+    fi
+
+    node_UID="$(id -u node 2>/dev/null)"  # The default UID for the node user
+    node_GID="$(id -g node 2>/dev/null)"  # The default GID for the node user
+
+    # Attempt to ensure the user uid we currently run as has a named entry in
+    # the /etc/passwd file, as it avoids software crashing on hard assumptions
+    # on such entry. Writing to the /etc/passwd was allowed for the root group
+    # from the Dockerfile during build.
+    #
+    # ref: https://github.com/jupyter/docker-stacks/issues/552
+    if ! whoami &> /dev/null; then
+        _log "There is no entry in /etc/passwd for our UID=$(id -u). Attempting to fix..."
+        if [[ -w /etc/passwd ]]; then
+            _log "Renaming old node user to nayvoj ($(id -u node):$(id -g node))"
+
+            # We cannot use "sed --in-place" since sed tries to create a temp file in
+            # /etc/ and we may not have write access. Apply sed on our own temp file:
+            sed --expression="s/^node:/nayvoj:/" /etc/passwd > /tmp/passwd
+            echo "${NB_USER}:x:$(id -u):$(id -g):,,,:/home/node:/bin/bash" >> /tmp/passwd
+            cat /tmp/passwd > /etc/passwd
+            rm /tmp/passwd
+
+            _log "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"
+
+            if [[ "${NB_USER}" != "node" ]]; then
+                _log "WARNING: user is ${NB_USER} but home is /home/node. You must run as root to rename the home directory!"
+            fi
+        else
+            _log "WARNING: unable to fix missing /etc/passwd entry because we don't have write permission. Try setting gid=0 with \"--user=$(id -u):0\"."
+        fi
+    fi
+
+    # Warn about misconfiguration of: desired username, user id, or group id.
+    # A misconfiguration occurs when the user modifies the default values of
+    # NB_USER, NB_UID, or NB_GID, but we cannot update those values because we
+    # are not root.
+    if [[ "${NB_USER}" != "node" && "${NB_USER}" != "$(id -un)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's name with NB_USER=\"${NB_USER}\"!"
+    fi
+    if [[ "${NB_UID}" != "${node_UID}" && "${NB_UID}" != "$(id -u)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's id with NB_UID=\"${NB_UID}\"!"
+    fi
+    if [[ "${NB_GID}" != "${node_GID}" && "${NB_GID}" != "$(id -g)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's group id with NB_GID=\"${NB_GID}\"!"
+    fi
+
+    # Warn if the user isn't able to write files to ${HOME}
+    if [[ ! -w /home/node ]]; then
+        _log "WARNING: no write access to /home/node. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
+    fi
+
+    # NOTE: This hook is run as the user we started the container as!
+    # shellcheck disable=SC1091
+    source /usr/local/bin/run-hooks.sh /usr/local/bin/before-notebook.d
+    unset_explicit_env_vars
+
+    _log "Executing the command:" "${cmd[@]}"
+    exec "${cmd[@]}"
+fi

--- a/Internal/docker-images/docker-stacks-foundation/start_backup.sh
+++ b/Internal/docker-images/docker-stacks-foundation/start_backup.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# The _log function is used for everything this script wants to log. It will
+# always log errors and warnings, but can be silenced for other messages
+# by setting JUPYTER_DOCKER_STACKS_QUIET environment variable.
+_log () {
+    if [[ "$*" == "ERROR:"* ]] || [[ "$*" == "WARNING:"* ]] || [[ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]]; then
+        echo "$@"
+    fi
+}
+_log "Entered start.sh with args:" "$@"
+
+# A helper function to unset env vars listed in the value of the env var
+# JUPYTER_ENV_VARS_TO_UNSET.
+unset_explicit_env_vars () {
+    if [ -n "${JUPYTER_ENV_VARS_TO_UNSET}" ]; then
+        for env_var_to_unset in $(echo "${JUPYTER_ENV_VARS_TO_UNSET}" | tr ',' ' '); do
+            _log "Unset ${env_var_to_unset} due to JUPYTER_ENV_VARS_TO_UNSET"
+            unset "${env_var_to_unset}"
+        done
+        unset JUPYTER_ENV_VARS_TO_UNSET
+    fi
+}
+
+
+# Default to starting bash if no command was specified
+if [ $# -eq 0 ]; then
+    cmd=( "bash" )
+else
+    cmd=( "$@" )
+fi
+
+# NOTE: This hook will run as the user the container was started with!
+# shellcheck disable=SC1091
+source /usr/local/bin/run-hooks.sh /usr/local/bin/start-notebook.d
+
+# If the container started as the root user, then we have permission to refit
+# the jovyan user, and ensure file permissions, grant sudo rights, and such
+# things before we run the command passed to start.sh as the desired user
+# (NB_USER).
+#
+if [ "$(id -u)" == 0 ] ; then
+    # Environment variables:
+    # - NB_USER: the desired username and associated home folder
+    # - NB_UID: the desired user id
+    # - NB_GID: a group id we want our user to belong to
+    # - NB_GROUP: a group name we want for the group
+    # - GRANT_SUDO: a boolean ("1" or "yes") to grant the user sudo rights
+    # - CHOWN_HOME: a boolean ("1" or "yes") to chown the user's home folder
+    # - CHOWN_EXTRA: a comma separated list of paths to chown
+    # - CHOWN_HOME_OPTS / CHOWN_EXTRA_OPTS: arguments to the chown commands
+
+    # Refit the jovyan user to the desired the user (NB_USER)
+    if id jovyan &> /dev/null ; then
+        if ! usermod --home "/home/${NB_USER}" --login "${NB_USER}" jovyan 2>&1 | grep "no changes" > /dev/null; then
+            _log "Updated the jovyan user:"
+            _log "- username: jovyan       -> ${NB_USER}"
+            _log "- home dir: /home/jovyan -> /home/${NB_USER}"
+        fi
+    elif ! id -u "${NB_USER}" &> /dev/null; then
+        _log "ERROR: Neither the jovyan user or '${NB_USER}' exists. This could be the result of stopping and starting, the container with a different NB_USER environment variable."
+        exit 1
+    fi
+    # Ensure the desired user (NB_USER) gets its desired user id (NB_UID) and is
+    # a member of the desired group (NB_GROUP, NB_GID)
+    if [ "${NB_UID}" != "$(id -u "${NB_USER}")" ] || [ "${NB_GID}" != "$(id -g "${NB_USER}")" ]; then
+        _log "Update ${NB_USER}'s UID:GID to ${NB_UID}:${NB_GID}"
+        # Ensure the desired group's existence
+        if [ "${NB_GID}" != "$(id -g "${NB_USER}")" ]; then
+            groupadd --force --gid "${NB_GID}" --non-unique "${NB_GROUP:-${NB_USER}}"
+        fi
+        # Recreate the desired user as we want it
+        userdel "${NB_USER}"
+        useradd --no-log-init --home "/home/${NB_USER}" --shell /bin/bash --uid "${NB_UID}" --gid "${NB_GID}" --groups 100 "${NB_USER}"
+    fi
+
+    # Move or symlink the jovyan home directory to the desired users home
+    # directory if it doesn't already exist, and update the current working
+    # directory to the new location if needed.
+    if [[ "${NB_USER}" != "jovyan" ]]; then
+        if [[ ! -e "/home/${NB_USER}" ]]; then
+            _log "Attempting to copy /home/jovyan to /home/${NB_USER}..."
+            mkdir "/home/${NB_USER}"
+            if cp -a /home/jovyan/. "/home/${NB_USER}/"; then
+                _log "Success!"
+            else
+                _log "Failed to copy data from /home/jovyan to /home/${NB_USER}!"
+                _log "Attempting to symlink /home/jovyan to /home/${NB_USER}..."
+                if ln -s /home/jovyan "/home/${NB_USER}"; then
+                    _log "Success creating symlink!"
+                else
+                    _log "ERROR: Failed copy data from /home/jovyan to /home/${NB_USER} or to create symlink!"
+                    exit 1
+                fi
+            fi
+        fi
+        # Ensure the current working directory is updated to the new path
+        if [[ "${PWD}/" == "/home/jovyan/"* ]]; then
+            new_wd="/home/${NB_USER}/${PWD:13}"
+            _log "Changing working directory to ${new_wd}"
+            cd "${new_wd}"
+        fi
+    fi
+
+    # Optionally ensure the desired user get filesystem ownership of it's home
+    # folder and/or additional folders
+    if [[ "${CHOWN_HOME}" == "1" || "${CHOWN_HOME}" == "yes" ]]; then
+        _log "Ensuring /home/${NB_USER} is owned by ${NB_UID}:${NB_GID} ${CHOWN_HOME_OPTS:+(chown options: ${CHOWN_HOME_OPTS})}"
+        # shellcheck disable=SC2086
+        chown ${CHOWN_HOME_OPTS} "${NB_UID}:${NB_GID}" "/home/${NB_USER}"
+    fi
+    if [ -n "${CHOWN_EXTRA}" ]; then
+        for extra_dir in $(echo "${CHOWN_EXTRA}" | tr ',' ' '); do
+            _log "Ensuring ${extra_dir} is owned by ${NB_UID}:${NB_GID} ${CHOWN_EXTRA_OPTS:+(chown options: ${CHOWN_EXTRA_OPTS})}"
+            # shellcheck disable=SC2086
+            chown ${CHOWN_EXTRA_OPTS} "${NB_UID}:${NB_GID}" "${extra_dir}"
+        done
+    fi
+
+    # Update potentially outdated environment variables since image build
+    export XDG_CACHE_HOME="/home/${NB_USER}/.cache"
+
+    # Prepend ${CONDA_DIR}/bin to sudo secure_path
+    sed -r "s#Defaults\s+secure_path\s*=\s*\"?([^\"]+)\"?#Defaults secure_path=\"${CONDA_DIR}/bin:\1\"#" /etc/sudoers | grep secure_path > /etc/sudoers.d/path
+
+    # Optionally grant passwordless sudo rights for the desired user
+    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == "yes" ]]; then
+        _log "Granting ${NB_USER} passwordless sudo rights!"
+        echo "${NB_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/added-by-start-script
+    fi
+
+    # NOTE: This hook is run as the root user!
+    # shellcheck disable=SC1091
+    source /usr/local/bin/run-hooks.sh /usr/local/bin/before-notebook.d
+    unset_explicit_env_vars
+
+    _log "Running as ${NB_USER}:" "${cmd[@]}"
+    exec sudo --preserve-env --set-home --user "${NB_USER}" \
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+        PATH="${PATH}" \
+        PYTHONPATH="${PYTHONPATH:-}" \
+        "${cmd[@]}"
+        # Notes on how we ensure that the environment that this container is started
+        # with is preserved (except vars listed in JUPYTER_ENV_VARS_TO_UNSET) when
+        # we transition from running as root to running as NB_USER.
+        #
+        # - We use `sudo` to execute the command as NB_USER. What then
+        #   happens to the environment will be determined by configuration in
+        #   /etc/sudoers and /etc/sudoers.d/* as well as flags we pass to the sudo
+        #   command. The behavior can be inspected with `sudo -V` run as root.
+        #
+        #   ref: `man sudo`    https://linux.die.net/man/8/sudo
+        #   ref: `man sudoers` https://www.sudo.ws/docs/man/sudoers.man/
+        #
+        # - We use the `--preserve-env` flag to pass through most environment
+        #   variables, but understand that exceptions are caused by the sudoers
+        #   configuration: `env_delete` and `env_check`.
+        #
+        # - We use the `--set-home` flag to set the HOME variable appropriately.
+        #
+        # - To reduce the default list of variables deleted by sudo, we could have
+        #   used `env_delete` from /etc/sudoers. It has higher priority than the
+        #   `--preserve-env` flag and the `env_keep` configuration.
+        #
+        # - We preserve LD_LIBRARY_PATH, PATH and PYTHONPATH explicitly. Note however that sudo
+        #   resolves `${cmd[@]}` using the "secure_path" variable we modified
+        #   above in /etc/sudoers.d/path. Thus PATH is irrelevant to how the above
+        #   sudo command resolves the path of `${cmd[@]}`. The PATH will be relevant
+        #   for resolving paths of any subprocesses spawned by `${cmd[@]}`.
+
+# The container didn't start as the root user, so we will have to act as the
+# user we started as.
+else
+    # Warn about misconfiguration of: granting sudo rights
+    if [[ "${GRANT_SUDO}" == "1" || "${GRANT_SUDO}" == "yes" ]]; then
+        _log "WARNING: container must be started as root to grant sudo permissions!"
+    fi
+
+    JOVYAN_UID="$(id -u jovyan 2>/dev/null)"  # The default UID for the jovyan user
+    JOVYAN_GID="$(id -g jovyan 2>/dev/null)"  # The default GID for the jovyan user
+
+    # Attempt to ensure the user uid we currently run as has a named entry in
+    # the /etc/passwd file, as it avoids software crashing on hard assumptions
+    # on such entry. Writing to the /etc/passwd was allowed for the root group
+    # from the Dockerfile during build.
+    #
+    # ref: https://github.com/jupyter/docker-stacks/issues/552
+    if ! whoami &> /dev/null; then
+        _log "There is no entry in /etc/passwd for our UID=$(id -u). Attempting to fix..."
+        if [[ -w /etc/passwd ]]; then
+            _log "Renaming old jovyan user to nayvoj ($(id -u jovyan):$(id -g jovyan))"
+
+            # We cannot use "sed --in-place" since sed tries to create a temp file in
+            # /etc/ and we may not have write access. Apply sed on our own temp file:
+            sed --expression="s/^jovyan:/nayvoj:/" /etc/passwd > /tmp/passwd
+            echo "${NB_USER}:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
+            cat /tmp/passwd > /etc/passwd
+            rm /tmp/passwd
+
+            _log "Added new ${NB_USER} user ($(id -u):$(id -g)). Fixed UID!"
+
+            if [[ "${NB_USER}" != "jovyan" ]]; then
+                _log "WARNING: user is ${NB_USER} but home is /home/jovyan. You must run as root to rename the home directory!"
+            fi
+        else
+            _log "WARNING: unable to fix missing /etc/passwd entry because we don't have write permission. Try setting gid=0 with \"--user=$(id -u):0\"."
+        fi
+    fi
+
+    # Warn about misconfiguration of: desired username, user id, or group id.
+    # A misconfiguration occurs when the user modifies the default values of
+    # NB_USER, NB_UID, or NB_GID, but we cannot update those values because we
+    # are not root.
+    if [[ "${NB_USER}" != "jovyan" && "${NB_USER}" != "$(id -un)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's name with NB_USER=\"${NB_USER}\"!"
+    fi
+    if [[ "${NB_UID}" != "${JOVYAN_UID}" && "${NB_UID}" != "$(id -u)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's id with NB_UID=\"${NB_UID}\"!"
+    fi
+    if [[ "${NB_GID}" != "${JOVYAN_GID}" && "${NB_GID}" != "$(id -g)" ]]; then
+        _log "WARNING: container must be started as root to change the desired user's group id with NB_GID=\"${NB_GID}\"!"
+    fi
+
+    # Warn if the user isn't able to write files to ${HOME}
+    if [[ ! -w /home/jovyan ]]; then
+        _log "WARNING: no write access to /home/jovyan. Try starting the container with group 'users' (100), e.g. using \"--group-add=users\"."
+    fi
+
+    # NOTE: This hook is run as the user we started the container as!
+    # shellcheck disable=SC1091
+    source /usr/local/bin/run-hooks.sh /usr/local/bin/before-notebook.d
+    unset_explicit_env_vars
+
+    _log "Executing the command:" "${cmd[@]}"
+    exec "${cmd[@]}"
+fi

--- a/Internal/docker-images/julia-notebook/.dockerignore
+++ b/Internal/docker-images/julia-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/julia-notebook/Dockerfile
+++ b/Internal/docker-images/julia-notebook/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/minimal-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Julia dependencies
+# install Julia packages in /opt/julia instead of ${HOME}
+ENV JULIA_DEPOT_PATH=/opt/julia \
+    JULIA_PKGDIR=/opt/julia
+
+# Setup Julia
+RUN /opt/setup-scripts/setup-julia.bash
+
+USER ${NB_UID}
+
+# Setup IJulia kernel & other packages
+RUN /opt/setup-scripts/setup-julia-packages.bash

--- a/Internal/docker-images/julia-notebook/README.md
+++ b/Internal/docker-images/julia-notebook/README.md
@@ -1,0 +1,12 @@
+# Jupyter Notebook Julia Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/julia-notebook.svg)](https://hub.docker.com/r/jupyter/julia-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/julia-notebook.svg)](https://hub.docker.com/r/jupyter/julia-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/julia-notebook/latest)](https://hub.docker.com/r/jupyter/julia-notebook/ "jupyter/julia-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/julia-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-julia-notebook)

--- a/Internal/docker-images/minimal-notebook/.dockerignore
+++ b/Internal/docker-images/minimal-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/minimal-notebook/Dockerfile
+++ b/Internal/docker-images/minimal-notebook/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# ARG OWNER=jupyter
+ARG OWNER=quiltbase
+ARG BASE_CONTAINER=${OWNER}/quilt-base-notebook:latest
+FROM $BASE_CONTAINER
+
+LABEL maintainer="GwooTeam <gwooteam@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Install all OS dependencies for fully functional Server
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    # Common useful utilities
+    curl \
+    git \
+    nano-tiny \
+    tzdata \
+    unzip \
+    vim-tiny \
+    # git-over-ssh
+    openssh-client \
+    # less is needed to run help in R
+    # see: https://github.com/jupyter/docker-stacks/issues/1588
+    less \
+    # nbconvert dependencies
+    # https://nbconvert.readthedocs.io/en/latest/install.html#installing-tex
+    texlive-xetex \
+    texlive-fonts-recommended \
+    texlive-plain-generic \
+    # Enable clipboard on Linux host systems
+    xclip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create alternative for nano -> nano-tiny
+RUN update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 10
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER ${NB_UID}
+
+# Add R mimetype option to specify how the plot returns from R to the browser
+COPY --chown=${NB_UID}:${NB_GID} Rprofile.site /opt/conda/lib/R/etc/
+
+# Add setup scripts that may be used by downstream images or inherited images
+COPY setup-scripts/ /opt/setup-scripts/

--- a/Internal/docker-images/minimal-notebook/README.md
+++ b/Internal/docker-images/minimal-notebook/README.md
@@ -1,0 +1,12 @@
+# Minimal Jupyter Notebook Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/minimal-notebook.svg)](https://hub.docker.com/r/jupyter/minimal-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/minimal-notebook.svg)](https://hub.docker.com/r/jupyter/minimal-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/minimal-notebook/latest)](https://hub.docker.com/r/jupyter/minimal-notebook/ "jupyter/minimal-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/minimal-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-minimal-notebook)

--- a/Internal/docker-images/minimal-notebook/Rprofile.site
+++ b/Internal/docker-images/minimal-notebook/Rprofile.site
@@ -1,0 +1,4 @@
+# Add R mimetype to specify how the plot returns from R to the browser.
+# https://notebook.community/andrie/jupyter-notebook-samples/Changing%20R%20plot%20options%20in%20Jupyter
+
+options(jupyter.plot_mimetypes = c('text/plain', 'image/png', 'image/jpeg', 'image/svg+xml', 'application/pdf'))

--- a/Internal/docker-images/minimal-notebook/setup-scripts/setup-julia-packages.bash
+++ b/Internal/docker-images/minimal-notebook/setup-scripts/setup-julia-packages.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -exuo pipefail
+# Requirements:
+# - Run as non-root user
+# - The JULIA_PKGDIR environment variable is set
+# - Julia is already set up, with the setup-julia.bash command
+
+# Install base Julia packages
+julia -e '
+import Pkg;
+Pkg.update();
+Pkg.add([
+    "HDF5",
+    "IJulia",
+    "Pluto"
+]);
+Pkg.precompile();
+'
+
+# Move the kernelspec out of ${HOME} to the system share location.
+# Avoids problems with runtime UID change not taking effect properly
+# on the .local folder in the jovyan home dir.
+mv "${HOME}/.local/share/jupyter/kernels/julia"* "${CONDA_DIR}/share/jupyter/kernels/"
+chmod -R go+rx "${CONDA_DIR}/share/jupyter"
+rm -rf "${HOME}/.local"
+fix-permissions "${JULIA_PKGDIR}" "${CONDA_DIR}/share/jupyter"
+
+# Install jupyter-pluto-proxy to get Pluto to work on JupyterHub
+mamba install --yes \
+    'jupyter-pluto-proxy' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/Internal/docker-images/minimal-notebook/setup-scripts/setup-julia.bash
+++ b/Internal/docker-images/minimal-notebook/setup-scripts/setup-julia.bash
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -exuo pipefail
+# Requirements:
+# - Run as the root user
+# - The JULIA_PKGDIR environment variable is set
+
+# Default julia version to install if env var is not set
+# Check https://julialang.org/downloads/
+JULIA_VERSION="${JULIA_VERSION:-1.9.3}"
+
+# Figure out what architecture we are installing in
+JULIA_ARCH=$(uname -m)
+JULIA_SHORT_ARCH="${JULIA_ARCH}"
+if [ "${JULIA_SHORT_ARCH}" == "x86_64" ]; then
+    JULIA_SHORT_ARCH="x64"
+fi
+
+# Figure out Julia Installer URL
+JULIA_INSTALLER="julia-${JULIA_VERSION}-linux-${JULIA_ARCH}.tar.gz"
+JULIA_MAJOR_MINOR=$(echo "${JULIA_VERSION}" | cut -d. -f 1,2)
+
+# Download and install Julia
+cd /tmp
+mkdir "/opt/julia-${JULIA_VERSION}"
+curl --progress-bar --location --output "${JULIA_INSTALLER}" \
+    "https://julialang-s3.julialang.org/bin/linux/${JULIA_SHORT_ARCH}/${JULIA_MAJOR_MINOR}/${JULIA_INSTALLER}"
+tar xzf "${JULIA_INSTALLER}" -C "/opt/julia-${JULIA_VERSION}" --strip-components=1
+rm "${JULIA_INSTALLER}"
+
+# Link Julia installed version to /usr/local/bin, so julia launches it
+ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia
+
+# Tell Julia where conda libraries are
+mkdir -p /etc/julia
+echo "push!(Libdl.DL_LOAD_PATH, \"${CONDA_DIR}/lib\")" >> /etc/julia/juliarc.jl
+
+# Create JULIA_PKGDIR, where user libraries are installed
+mkdir "${JULIA_PKGDIR}"
+chown "${NB_USER}" "${JULIA_PKGDIR}"
+fix-permissions "${JULIA_PKGDIR}"

--- a/Internal/docker-images/pyspark-notebook/.dockerignore
+++ b/Internal/docker-images/pyspark-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/pyspark-notebook/Dockerfile
+++ b/Internal/docker-images/pyspark-notebook/Dockerfile
@@ -1,0 +1,118 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# ARG OWNER=jupyter
+ARG OWNER=quiltbase
+ARG BASE_CONTAINER=${OWNER}/quilt-scipy-notebook:latest
+FROM $BASE_CONTAINER
+
+LABEL maintainer="GwooTeam <gwooteam@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Spark dependencies
+# Default values can be overridden at build time
+# (ARGS are in lower case to distinguish them from ENV)
+ARG spark_version="3.5.0"
+ARG hadoop_version="3"
+ARG scala_version
+ARG spark_checksum="8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
+ARG openjdk_version="17"
+
+ENV APACHE_SPARK_VERSION="${spark_version}" \
+    HADOOP_VERSION="${hadoop_version}"
+
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    "openjdk-${openjdk_version}-jre-headless" \
+    ca-certificates-java && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Spark installation
+WORKDIR /tmp
+
+# You need to use https://archive.apache.org/dist/ website if you want to download old Spark versions
+# But it seems to be slower, that's why we use recommended site for download
+RUN if [ -z "${scala_version}" ]; then \
+    curl --progress-bar --location --output "spark.tgz" \
+        "https://dlcdn.apache.org/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz"; \
+  else \
+    curl --progress-bar --location --output "spark.tgz" \
+        "https://dlcdn.apache.org/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala${scala_version}.tgz"; \
+  fi && \
+  echo "${spark_checksum} *spark.tgz" | sha512sum -c - && \
+  tar xzf "spark.tgz" -C /usr/local --owner root --group root --no-same-owner && \
+  rm "spark.tgz"
+
+# Configure Spark
+ENV SPARK_HOME=/usr/local/spark
+ENV SPARK_OPTS="--driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info" \
+    PATH="${PATH}:${SPARK_HOME}/bin"
+
+RUN if [ -z "${scala_version}" ]; then \
+    ln -s "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}" "${SPARK_HOME}"; \
+  else \
+    ln -s "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala${scala_version}" "${SPARK_HOME}"; \
+  fi && \
+  # Add a link in the before_notebook hook in order to source automatically PYTHONPATH && \
+  ln -s "${SPARK_HOME}/sbin/spark-config.sh" /usr/local/bin/before-notebook.d/spark-config.sh
+
+# Configure IPython system-wide
+COPY ipython_kernel_config.py "/etc/ipython/"
+RUN fix-permissions "/etc/ipython/"
+
+USER ${NB_UID}
+
+# Install pyarrow
+# NOTE: It's important to ensure compatibility between Pandas versions.
+# The pandas version in this Dockerfile should match the version
+# on which the Pandas API for Spark is built.
+# To find the right version:
+# 1. Check out the Spark branch you are on.
+# 2. Find the pandas version in the file spark/dev/infra/Dockerfile.
+RUN mamba install --yes \
+    'pandas=2.0.3' \
+    'pyarrow' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# 230927 added
+# add jupyter notebook config
+# USER root
+# RUN pip install nbextension \
+#     pip install jupyter_contrib_nbextensions \
+#     pip install --upgrade notebook==6.4.12 \
+#     jupyter contrib nbextension install --user
+
+# COPY jupyter_notebook_config.py ~/.jupyter/
+
+# USER ${NB_UID}
+
+# 230928 added, 231003 modify
+USER root
+
+COPY nbext.sh /home/node/.jupyter/
+
+RUN chmod +x /home/node/.jupyter/nbext.sh
+# RUN chmod -R 777 /home/node/.local/
+RUN /home/node/.jupyter/nbext.sh
+
+# RUN pip install jupyter_contrib_nbextensions \
+#     pip install --upgrade notebook==6.4.12 \
+#     jupyter contrib nbextension install --user
+
+COPY jupyter_notebook_config.py /home/node/.jupyter/
+RUN chmod +x /home/node/.jupyter/jupyter_notebook_config.py
+
+RUN chmod -R 777 /home/node/
+
+USER ${NB_UID}
+
+# 230928 added
+
+WORKDIR "${HOME}"
+EXPOSE 4040

--- a/Internal/docker-images/pyspark-notebook/README.md
+++ b/Internal/docker-images/pyspark-notebook/README.md
@@ -1,0 +1,13 @@
+# Jupyter Notebook Python, Spark Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/pyspark-notebook.svg)](https://hub.docker.com/r/jupyter/pyspark-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/pyspark-notebook.svg)](https://hub.docker.com/r/jupyter/pyspark-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/pyspark-notebook/latest)](https://hub.docker.com/r/jupyter/pyspark-notebook/ "jupyter/pyspark-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/pyspark-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-pyspark-notebook)
+- [Image Specifics :: Apache Spark](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/specifics.html#apache-spark)

--- a/Internal/docker-images/pyspark-notebook/ipython_kernel_config.py
+++ b/Internal/docker-images/pyspark-notebook/ipython_kernel_config.py
@@ -1,0 +1,14 @@
+# Configuration file for ipython-kernel.
+# See <https://ipython.readthedocs.io/en/stable/config/options/kernel.html>
+
+# With IPython >= 6.0.0, all outputs to stdout/stderr are captured.
+# It is the case for subprocesses and output of compiled libraries like Spark.
+# Those logs now both head to notebook logs and in notebooks outputs.
+# Logs are particularly verbose with Spark, that is why we turn them off through this flag.
+# <https://github.com/jupyter/docker-stacks/issues/1423>
+
+# Attempt to capture and forward low-level output, e.g. produced by Extension
+#  libraries.
+#  Default: True
+# type:ignore
+c.IPKernelApp.capture_fd_output = False  # noqa: F821

--- a/Internal/docker-images/pyspark-notebook/jupyter_notebook_config.py
+++ b/Internal/docker-images/pyspark-notebook/jupyter_notebook_config.py
@@ -1,0 +1,14 @@
+from notebook.services.contents.filemanager import FileContentsManager
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def pre_save_hook(model, **kwargs):
+    # Your custom pre-save action here
+    # print("Performing custom pre-save action for new notebook.")
+    logger.info("Performing custom pre-save action for new notebook.")
+
+# Register the pre-save hook
+c.FileContentsManager.pre_save_hook = pre_save_hook

--- a/Internal/docker-images/pyspark-notebook/nbext.sh
+++ b/Internal/docker-images/pyspark-notebook/nbext.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Install and upgrade notebook to version 6.4.12
+pip install --upgrade notebook==6.4.12
+
+# Install jupyter_contrib_nbextensions and Install Jupyter Notebook extensions
+pip install jupyter_contrib_nbextensions
+
+# Install Jupyter Notebook extensions
+jupyter contrib nbextension install --user

--- a/Internal/docker-images/r-notebook/.dockerignore
+++ b/Internal/docker-images/r-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/r-notebook/Dockerfile
+++ b/Internal/docker-images/r-notebook/Dockerfile
@@ -1,0 +1,53 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/minimal-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# R pre-requisites
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    fonts-dejavu \
+    unixodbc \
+    unixodbc-dev \
+    r-cran-rodbc \
+    gfortran \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER ${NB_UID}
+
+# R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
+RUN mamba install --yes \
+    'r-base' \
+    'r-caret' \
+    'r-crayon' \
+    'r-devtools' \
+    'r-e1071' \
+    'r-forecast' \
+    'r-hexbin' \
+    'r-htmltools' \
+    'r-htmlwidgets' \
+    'r-irkernel' \
+    'r-nycflights13' \
+    'r-randomforest' \
+    'r-rcurl' \
+    'r-rmarkdown' \
+    'r-rodbc' \
+    'r-rsqlite' \
+    'r-shiny' \
+    'r-tidymodels' \
+    'r-tidyverse' \
+    'unixodbc' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/Internal/docker-images/r-notebook/README.md
+++ b/Internal/docker-images/r-notebook/README.md
@@ -1,0 +1,12 @@
+# Jupyter Notebook R Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/r-notebook.svg)](https://hub.docker.com/r/jupyter/r-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/r-notebook.svg)](https://hub.docker.com/r/jupyter/r-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/r-notebook/latest)](https://hub.docker.com/r/jupyter/r-notebook/ "jupyter/r-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/r-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-r-notebook)

--- a/Internal/docker-images/scipy-notebook/.dockerignore
+++ b/Internal/docker-images/scipy-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/scipy-notebook/Dockerfile
+++ b/Internal/docker-images/scipy-notebook/Dockerfile
@@ -1,0 +1,85 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# ARG OWNER=jupyter
+ARG OWNER=quiltbase
+ARG BASE_CONTAINER=${OWNER}/quilt-minimal-notebook:latest
+FROM $BASE_CONTAINER
+
+LABEL maintainer="GwooTeam <gwooteam@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    # for cython: https://cython.readthedocs.io/en/latest/src/quickstart/install.html
+    build-essential \
+    # for latex labels
+    cm-super \
+    dvipng \
+    # for matplotlib anim
+    ffmpeg && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER ${NB_UID}
+
+# mamba downgrades these packages to previous major versions, which causes issues
+RUN echo 'jupyterlab >=4.0.4' >> "${CONDA_DIR}/conda-meta/pinned" && \
+    echo 'notebook >=7.0.2' >> "${CONDA_DIR}/conda-meta/pinned"
+
+# Install Python 3 packages
+RUN mamba install --yes \
+    'altair' \
+    'beautifulsoup4' \
+    'bokeh' \
+    'bottleneck' \
+    'cloudpickle' \
+    'conda-forge::blas=*=openblas' \
+    'cython' \
+    'dask' \
+    'dill' \
+    'h5py' \
+    'ipympl'\
+    'ipywidgets' \
+    'jupyterlab-git' \
+    'matplotlib-base' \
+    'numba' \
+    'numexpr' \
+    'openpyxl' \
+    'pandas' \
+    'patsy' \
+    'protobuf' \
+    'pytables' \
+    'scikit-image' \
+    'scikit-learn' \
+    'scipy' \
+    'seaborn' \
+    'sqlalchemy' \
+    'statsmodels' \
+    'sympy' \
+    'widgetsnbextension'\
+    'xlrd' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# Install facets which does not have a pip or conda package at the moment
+WORKDIR /tmp
+RUN git clone https://github.com/PAIR-code/facets && \
+    jupyter nbclassic-extension install facets/facets-dist/ --sys-prefix && \
+    rm -rf /tmp/facets && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# Import matplotlib the first time to build the font cache.
+ENV XDG_CACHE_HOME="/home/${NB_USER}/.cache/"
+
+RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot" && \
+    fix-permissions "/home/${NB_USER}"
+
+USER ${NB_UID}
+
+WORKDIR "${HOME}"

--- a/Internal/docker-images/scipy-notebook/README.md
+++ b/Internal/docker-images/scipy-notebook/README.md
@@ -1,0 +1,12 @@
+# Jupyter Notebook Scientific Python Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/scipy-notebook.svg)](https://hub.docker.com/r/jupyter/scipy-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/scipy-notebook.svg)](https://hub.docker.com/r/jupyter/scipy-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/scipy-notebook/latest)](https://hub.docker.com/r/jupyter/scipy-notebook/ "jupyter/scipy-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/scipy-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook)

--- a/Internal/docker-images/tensorflow-notebook/.dockerignore
+++ b/Internal/docker-images/tensorflow-notebook/.dockerignore
@@ -1,0 +1,2 @@
+# Documentation
+README.md

--- a/Internal/docker-images/tensorflow-notebook/Dockerfile
+++ b/Internal/docker-images/tensorflow-notebook/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/scipy-notebook
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install Tensorflow with pip
+RUN pip install --no-cache-dir tensorflow && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"

--- a/Internal/docker-images/tensorflow-notebook/README.md
+++ b/Internal/docker-images/tensorflow-notebook/README.md
@@ -1,0 +1,13 @@
+# Jupyter Notebook Deep Learning Stack
+
+[![docker pulls](https://img.shields.io/docker/pulls/jupyter/tensorflow-notebook.svg)](https://hub.docker.com/r/jupyter/tensorflow-notebook/)
+[![docker stars](https://img.shields.io/docker/stars/jupyter/tensorflow-notebook.svg)](https://hub.docker.com/r/jupyter/tensorflow-notebook/)
+[![image size](https://img.shields.io/docker/image-size/jupyter/tensorflow-notebook/latest)](https://hub.docker.com/r/jupyter/tensorflow-notebook/ "jupyter/tensorflow-notebook image size")
+
+GitHub Actions in the <https://github.com/jupyter/docker-stacks> project builds and pushes this image to Docker Hub.
+
+Please visit the project documentation site for help to use and contribute to this image and others.
+
+- [Jupyter Docker Stacks on ReadTheDocs](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html)
+- [Selecting an Image :: Core Stacks :: jupyter/tensorflow-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-tensorflow-notebook)
+- [Image Specifics :: Tensorflow](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/specifics.html#tensorflow)


### PR DESCRIPTION
### Motivation 
-  tgrid RFC를 통해 명령을 내리고 실제 동작할 도커 컨테이너의 dockerfile, config 파일 실체

### Key Change
- 실제 동작할 도커 이미지 (quiltbase/quilt-pyspark-notebook)를 빌드하는 dockerfile 추가
- jupyter extension 확장기능을 추가한 jupyter-notebook-config.py 파일 추가
- quilt-pyspark-notebook의 기반 이미지들의 dockerfile 및 각종 설정 파일 (start.sh 등) 추가
- quilt-pyspark-notebook의 기반 이미지 layer (하위->상위 순)
- docker-stacks-foundation
- base-notebook
- minimal-notebook
- scipy-notebook

### To Reviewer
- 기존 jupyter project의 오픈 소스를 수정한 것
- 기존 오픈소스에서의 주요 수정 내용은 다음과 같음
- 1. 컨테이너의 기본 유저명을 jovyan에서 node로 변경
- 2. 모든 기반 이미지 dockerfile의 maintainer를 gwooteam@googlegroups.com으로 변경
- 3. docker-stacks-foundation을 제외한 모든 기반 이미지 dockerfile의 base-container 경로를 quiltbase로 변경
- 4. jupyter extension을 위한 파일 추가 (jupyter-notebook-config.py, nbext.sh)
- jupyter project 코드의 copyright (c) ~~ 부분은 라이선스상 지우면 안됨.
- !!! jupyter extension을 통한 구현은 완료되었는데.. 생각하던거랑 다르게 동작해서 다른 방식을 찾아야 할 가능성이 생김. (notebook 파일 생성 시 처음 한번만 스크립트가 실행해야 하는데 파일을 저장할 때마다 스크립트가 실행됨)
