### PR TITLE
build-docker-images.yml 파일 수정

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -20,31 +20,31 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build foundation
-        run: docker build -t quiltbase/quilt-foundation:latest ./docker-stacks-foundation
+        run: docker build -t quiltbase/quilt-foundation:latest ./Internal/docker-images/docker-stacks-foundation
 
       - name: Push foundation
         run: docker push quiltbase/quilt-foundation:latest
 
       - name: Bulld base-notebook
-        run: docker build -t quiltbase/quilt-base-notebook:latest ./base-notebook
+        run: docker build -t quiltbase/quilt-base-notebook:latest ./Internal/docker-images/base-notebook
 
       - name: Push base-notebook
         run: docker push quiltbase/quilt-base-notebook:latest
 
       - name: Build minimal-notebook
-        run: docker build -t quiltbase/quilt-minimal-notebook:latest ./minimal-notebook
+        run: docker build -t quiltbase/quilt-minimal-notebook:latest ./Internal/docker-images/minimal-notebook
 
       - name: Push minimal-notebook
         run: docker push quiltbase/quilt-minimal-notebook:latest
 
       - name: Build scipy-notebook
-        run: docker build -t quiltbase/quilt-scipy-notebook:latest ./scipy-notebook
+        run: docker build -t quiltbase/quilt-scipy-notebook:latest ./Internal/docker-images/scipy-notebook
 
       - name: Push scipy-notebook
         run: docker push quiltbase/quilt-scipy-notebook:latest
 
       - name: Build pyspark-notebook
-        run: docker build -t quiltbase/quilt-pyspark-notebook:latest ./pyspark-notebook
+        run: docker build -t quiltbase/quilt-pyspark-notebook:latest ./Internal/docker-images/pyspark-notebook
 
       - name: Push pyspark-notebook
         run: docker push quiltbase/quilt-pyspark-notebook:latest


### PR DESCRIPTION
### Motivation 
- 도커 이미지 빌드 경로가 맞지 않아 빌드에 실패함
- 빌드 경로를 프로젝트 리포지토리에 맞게 수정 필요

### Key Change
- build-docker-images.yml의 빌드 경로 옵션을 ./~~에서 ./Internal/docker-images/~~ 로 변경

### To Reviewer
- 
